### PR TITLE
feat: added the ability to scrape single or multiple mod id's

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,21 @@ This will:
 
 ### Scrape Command
 
-The `scrape` command fetches mod information and outputs JSON.
+The `scrape` command fetches mod information and outputs JSON. You can pass a single mod ID or a comma-separated list of mod IDs.
 
 ```bash
-./nexus-mods-scraper scrape <game-name> <mod-id> [flags]
+./nexus-mods-scraper scrape <game-name> <mod-id or comma-separated mod ids> [flags]
 ```
 
-#### Example
+#### Examples
 
 ```bash
+# Single mod
 ./nexus-mods-scraper scrape cyberpunk2077 26976
+
+# Multiple mods (comma-separated; spaces optional)
+./nexus-mods-scraper scrape cyberpunk2077 26976,123,456
+./nexus-mods-scraper scrape skyrimspecialedition 3863, 1234
 ```
 
 #### Flags
@@ -141,11 +146,19 @@ Use `--quiet` (or `-q`) to suppress spinners and status messages, making the out
 # Save to file
 ./nexus-mods-scraper scrape cyberpunk2077 26976 -q > mod-info.json
 
-# Extract specific fields
+# Extract specific fields (single mod)
 ./nexus-mods-scraper scrape skyrimspecialedition 3863 -q | jq '{name: .Name, version: .LatestVersion}'
+
+# Multiple mods: output is a JSON array; use jq '.[]' to iterate
+./nexus-mods-scraper scrape skyrimspecialedition 3863,1234 -q | jq '.[] | .Name'
 ```
 
-#### Output Example
+#### Output
+
+- **Single mod**: one JSON object (same as before).
+- **Multiple mods**: one JSON array of mod objects `[{...}, {...}]`.
+
+Example (single mod):
 
 ```json
 {
@@ -175,6 +188,8 @@ Use `--quiet` (or `-q`) to suppress spinners and status messages, making the out
   "VirusStatus": "Safe to use"
 }
 ```
+
+When saving with `--save-results`, one JSON file is written per mod in `<output-directory>/<game-name>/` (e.g. `mod name 26976.json`).
 
 ## Supported Browsers
 

--- a/cmd/cli/extract_test.go
+++ b/cmd/cli/extract_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockCookieStore is a test double for kooky.CookieStore used in extract tests.
@@ -191,9 +192,7 @@ func TestExtractCookies_Success(t *testing.T) {
 
 	// Verify the contents of the temp file
 	fileContent, err := os.ReadFile(tempFilePath)
-	if err != nil {
-		t.Fatalf("Failed to read temp file: %v", err)
-	}
+	require.NoError(t, err)
 
 	expectedContent := `{
     "session": "1234"
@@ -386,7 +385,7 @@ func TestExtractCookies_WithValidationSuccess(t *testing.T) {
 	mockStore.AssertExpectations(t)
 	path := filepath.Join(tempDir, "session-cookies.json")
 	content, err := os.ReadFile(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(content), "1234")
 }
 
@@ -607,7 +606,7 @@ func TestExtractCookies_ValidationSuccess_NoUsername(t *testing.T) {
 	mockStore.AssertExpectations(t)
 	path := filepath.Join(tempDir, "session-cookies.json")
 	content, err := os.ReadFile(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(content), "abc")
 }
 
@@ -639,7 +638,7 @@ func TestExtractCookies_Interactive_Manual(t *testing.T) {
 	assert.NoError(t, err)
 	path := filepath.Join(tempDir, "session-cookies.json")
 	content, err := os.ReadFile(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(content), "manual-value")
 }
 
@@ -672,7 +671,7 @@ func TestExtractCookies_Interactive_AutoSuccess(t *testing.T) {
 
 	assert.NoError(t, err)
 	content, err := os.ReadFile(filepath.Join(tempDir, "session-cookies.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(content), "auto-value")
 }
 
@@ -708,7 +707,7 @@ func TestExtractCookies_Interactive_AutoFailThenManual(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, confirmCalled)
 	content, err := os.ReadFile(filepath.Join(tempDir, "session-cookies.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(content), "fallback-value")
 }
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -21,6 +21,8 @@ var RootCmd = &cobra.Command{
 	Short: "A CLI tool to scrape https://nexusmods.com mods and return the information in JSON format",
 }
 
+// init registers the root command's persistent flags (e.g. quiet) and the PersistentPreRunE
+// hook that clears the terminal unless quiet mode is set.
 func init() {
 	RootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress spinner and status output (for piping to jq)")
 	_ = viper.BindPFlags(RootCmd.PersistentFlags())

--- a/cmd/cli/root_test.go
+++ b/cmd/cli/root_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestRootCmd_Initialized verifies RootCmd has expected Use and Short.
 func TestRootCmd_Initialized(t *testing.T) {
 	// Ensure that RootCmd is correctly initialized
 	assert.Equal(t, "nexus-mods-scraper", RootCmd.Use)
 	assert.Equal(t, "A CLI tool to scrape https://nexusmods.com mods and return the information in JSON format", RootCmd.Short)
 }
 
+// TestExecute_Success verifies Execute returns nil when root command succeeds.
 func TestExecute_Success(t *testing.T) {
 	origRoot := RootCmd
 	defer func() { RootCmd = origRoot }()
@@ -32,6 +34,7 @@ func TestExecute_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestExecute_Failure verifies Execute returns the root command error.
 func TestExecute_Failure(t *testing.T) {
 	origRoot := RootCmd
 	defer func() { RootCmd = origRoot }()
@@ -50,6 +53,7 @@ func TestExecute_Failure(t *testing.T) {
 	assert.Equal(t, "execution failed", err.Error())
 }
 
+// TestRootCmd_PersistentPreRunE_QuietSkipsClear verifies clear is skipped when quiet is set.
 func TestRootCmd_PersistentPreRunE_QuietSkipsClear(t *testing.T) {
 	origQuiet := viper.Get("quiet")
 	viper.Set("quiet", true)
@@ -59,6 +63,7 @@ func TestRootCmd_PersistentPreRunE_QuietSkipsClear(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestRootCmd_PersistentPreRunE_ClearTerminalSuccess verifies pre-run clears terminal when not quiet.
 func TestRootCmd_PersistentPreRunE_ClearTerminalSuccess(t *testing.T) {
 	orig := clearTerminalScreen
 	defer func() { clearTerminalScreen = orig }()
@@ -72,6 +77,7 @@ func TestRootCmd_PersistentPreRunE_ClearTerminalSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestRootCmd_PersistentPreRunE_ClearTerminalError verifies pre-run returns error when clear fails.
 func TestRootCmd_PersistentPreRunE_ClearTerminalError(t *testing.T) {
 	orig := clearTerminalScreen
 	defer func() { clearTerminalScreen = orig }()

--- a/cmd/cli/scrape.go
+++ b/cmd/cli/scrape.go
@@ -92,6 +92,7 @@ var (
 	createSpinner = func(start, stopCh, stopMsg, failCh, failMsg string) spinnerI {
 		return spinners.CreateSpinner(start, stopCh, stopMsg, failCh, failMsg)
 	}
+	strToInt64SliceFunc func(string) ([]int64, error) = formatters.StrToInt64Slice
 	// fetchModInfoFunc is a variable that holds a reference to the function used for
 	// concurrently fetching mod information.
 	fetchModInfoFunc = fetchers.FetchModInfoConcurrent
@@ -114,7 +115,9 @@ func init() {
 	}
 
 	initScrapeFlags(scrapeCmd)
-	viper.BindPFlags(scrapeCmd.Flags())
+	if err := viper.BindPFlags(scrapeCmd.Flags()); err != nil {
+		panic("scrape: bind flags: " + err.Error())
+	}
 	RootCmd.AddCommand(scrapeCmd)
 }
 
@@ -140,7 +143,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if !options.DisplayResults && !options.SaveResults {
 		return fmt.Errorf("at least one of --display-results (-r) or --save-results (-s) must be enabled")
 	}
-	modIDs, err := formatters.StrToInt64Slice(args[1])
+	modIDs, err := strToInt64SliceFunc(args[1])
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/scrape_test.go
+++ b/cmd/cli/scrape_test.go
@@ -120,6 +120,8 @@ func TestSanitizeFilename(t *testing.T) {
 		{"truncation at max length", strings.Repeat("a", 250), 99, strings.Repeat("a", maxFilenameLength)},
 		{"truncation then trim trailing space", strings.Repeat("x", 198) + "   ", 1, strings.Repeat("x", 198)},
 		{"truncation then trim multiple trailing spaces", strings.Repeat("a", 197) + "     ", 2, strings.Repeat("a", 197)},
+		// After collapse/trim, length must be >200 so truncation runs; then rune[199] is space so trim loop runs
+		{"truncation then trim single trailing space", strings.Repeat("x", 199) + " x", 1, strings.Repeat("x", 199)},
 		{"long spaces only trim to empty fallback", strings.Repeat(" ", 200), 7, "file_7"},
 	}
 	for _, tt := range tests {

--- a/cmd/cli/version_test.go
+++ b/cmd/cli/version_test.go
@@ -8,6 +8,7 @@ import (
 	"go.szostok.io/version/extension"
 )
 
+// TestInit_VersionCommandAdded verifies the version subcommand is registered on root.
 func TestInit_VersionCommandAdded(t *testing.T) {
 	// Create a new RootCmd without initializing it
 	rootCmd := &cobra.Command{}

--- a/internal/fetchers/fetchers_test.go
+++ b/internal/fetchers/fetchers_test.go
@@ -22,6 +22,9 @@ type Mocker struct {
 // Do implements the HTTPClient interface for the mock.
 func (m *Mocker) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 
@@ -33,12 +36,18 @@ func (m *Mocker) SetCookies(u *url.URL, cookies []*http.Cookie) {
 // Cookies returns the mock's canned cookies for the given URL.
 func (m *Mocker) Cookies(u *url.URL) []*http.Cookie {
 	args := m.Called(u)
+	if args.Get(0) == nil {
+		return nil
+	}
 	return args.Get(0).([]*http.Cookie)
 }
 
 // RoundTrip implements http.RoundTripper for the mock.
 func (m *Mocker) RoundTrip(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -93,33 +93,14 @@ func TestSetCookiesFromFile_Success(t *testing.T) {
 	// Create the URL for the domain
 	u, _ := url.Parse(domain)
 
-	// Create a mock CookieJar and mock its behavior
-	mockJar := new(Mocker)
-	mockClient := &http.Client{Jar: mockJar}
-	Client = mockClient
-
-	// Create the mock cookies to be returned
-	mockCookies := []*http.Cookie{
-		{
-			Name:  "session",
-			Value: "1234",
-		},
-	}
-
-	// Mock the SetCookies behavior, ensuring we capture the cookies argument
-	mockJar.On("SetCookies", u, mock.MatchedBy(func(cookies []*http.Cookie) bool {
-		return len(cookies) == 1 && cookies[0].Name == "session" && cookies[0].Value == "1234"
-	})).Return()
-
-	// Mock the Cookies behavior to return the mock cookies
-	mockJar.On("Cookies", u).Return(mockCookies)
-
 	// Act
 	err = InitClient(domain, dir, filename)
 	assert.NoError(t, err)
 
-	// Assert
-	cookies := mockJar.Cookies(u)
+	// Assert: verify cookies were set on the real jar
+	realClient, ok := Client.(*http.Client)
+	require.True(t, ok)
+	cookies := realClient.Jar.Cookies(u)
 	assert.Len(t, cookies, 1)
 	assert.Equal(t, "session", cookies[0].Name)
 	assert.Equal(t, "1234", cookies[0].Value)

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -18,20 +18,24 @@ type Mocker struct {
 	mock.Mock
 }
 
+// Do implements the HTTPClient interface for the mock.
 func (m *Mocker) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 
+// SetCookies records the call for the mock cookie jar.
 func (m *Mocker) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	m.Called(u, cookies)
 }
 
+// Cookies returns the mock's canned cookies for the given URL.
 func (m *Mocker) Cookies(u *url.URL) []*http.Cookie {
 	args := m.Called(u)
 	return args.Get(0).([]*http.Cookie)
 }
 
+// TestInitClient_Success verifies InitClient with a valid cookie file.
 func TestInitClient_Success(t *testing.T) {
 	// Arrange
 	domain := "https://example.com"
@@ -60,6 +64,7 @@ func TestInitClient_Success(t *testing.T) {
 	assert.IsType(t, &http.Client{}, Client)
 }
 
+// TestSetCookiesFromFile_Success verifies setCookiesFromFile with valid JSON.
 func TestSetCookiesFromFile_Success(t *testing.T) {
 	// Arrange
 	domain := "https://example.com"
@@ -115,6 +120,7 @@ func TestSetCookiesFromFile_Success(t *testing.T) {
 
 }
 
+// TestSetCookiesFromFile_FileError checks error when the cookie file cannot be opened.
 func TestSetCookiesFromFile_FileError(t *testing.T) {
 	// Arrange
 	domain := "https://example.com"
@@ -129,6 +135,7 @@ func TestSetCookiesFromFile_FileError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error opening cookie file")
 }
 
+// TestSetCookiesFromFile_JSONError checks error when cookie file JSON is invalid.
 func TestSetCookiesFromFile_JSONError(t *testing.T) {
 	// Arrange
 	domain := "https://example.com"
@@ -152,6 +159,7 @@ func TestSetCookiesFromFile_JSONError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error decoding JSON")
 }
 
+// TestInitClient_InvalidDomain checks error when domain cannot be parsed.
 func TestInitClient_InvalidDomain(t *testing.T) {
 	dir := t.TempDir()
 	filename := "cookies.json"
@@ -167,6 +175,7 @@ func TestInitClient_InvalidDomain(t *testing.T) {
 }
 
 // TestInitClient_DomainWithoutScheme covers setCookiesFromFile when domain has no scheme
+// TestInitClient_DomainWithoutScheme verifies InitClient accepts domain without scheme
 // (e.g. "example.com"); the code adds "https://" and parses again.
 func TestInitClient_DomainWithoutScheme(t *testing.T) {
 	defer func() { Client = nil }()
@@ -183,6 +192,7 @@ func TestInitClient_DomainWithoutScheme(t *testing.T) {
 }
 
 // TestSetCookiesFromFile_InvalidDomainEmptyHostname covers the error path when the domain
+// TestSetCookiesFromFile_InvalidDomainEmptyHostname checks error when domain
 // parses but hostname is still empty after prepending "https://".
 func TestSetCookiesFromFile_InvalidDomainEmptyHostname(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -8,7 +8,7 @@ import (
 // cli related.
 // CliFlags defines the structure for command-line flags, including options such as
 // the base URL, cookie directory, cookie file, display and save result flags, game name,
-// mod ID, output directory, and valid cookies for the operation.
+// mod IDs (comma-separated from CLI), output directory, and valid cookies for the operation.
 type CliFlags struct {
 	BaseUrl                   string
 	CookieDirectory           string
@@ -17,7 +17,7 @@ type CliFlags struct {
 	DisplayResults            bool
 	GameName                  string
 	Interactive               bool
-	ModID                     int64
+	ModIDs                    []int64
 	NoValidate                bool
 	OutputDirectory           string
 	Quiet                     bool

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-// cli related.
 // CliFlags defines the structure for command-line flags, including options such as
 // the base URL, cookie directory, cookie file, display and save result flags, game name,
 // mod IDs (comma-separated from CLI), output directory, and valid cookies for the operation.

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -20,7 +20,7 @@ func TestNewScraper(t *testing.T) {
 	assert.Equal(t, "", scraper.CookieFile)
 	assert.False(t, scraper.DisplayResults)
 	assert.Equal(t, "", scraper.GameName)
-	assert.Equal(t, int64(0), scraper.ModID)
+	assert.Nil(t, scraper.ModIDs)
 	assert.Equal(t, "", scraper.OutputDirectory)
 	assert.False(t, scraper.SaveResults)
 	assert.Empty(t, scraper.ValidCookies)

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestNewScraper verifies NewScraper returns a CliFlags with expected defaults.
 func TestNewScraper(t *testing.T) {
 	// Act
 	scraper := NewScraper()
@@ -26,6 +27,7 @@ func TestNewScraper(t *testing.T) {
 	assert.Empty(t, scraper.ValidCookies)
 }
 
+// TestModInfoJSONMarshalling checks ModInfo JSON marshal/unmarshal round-trip.
 func TestModInfoJSONMarshalling(t *testing.T) {
 	// Arrange
 	modInfo := ModInfo{
@@ -65,6 +67,7 @@ func TestModInfoJSONMarshalling(t *testing.T) {
 	assert.JSONEq(t, expectedJSON, string(data))
 }
 
+// TestResultsJSONMarshalling checks Results JSON marshal/unmarshal round-trip.
 func TestResultsJSONMarshalling(t *testing.T) {
 	// Arrange
 	results := Results{
@@ -83,6 +86,7 @@ func TestResultsJSONMarshalling(t *testing.T) {
 	assert.Contains(t, string(data), `"Mods"`)
 }
 
+// TestRequirementStruct verifies Requirement fields and JSON tags.
 func TestRequirementStruct(t *testing.T) {
 	// Arrange
 	req := Requirement{
@@ -99,6 +103,7 @@ func TestRequirementStruct(t *testing.T) {
 	assert.JSONEq(t, expectedJSON, string(data))
 }
 
+// TestFileStruct verifies File struct fields and JSON marshalling.
 func TestFileStruct(t *testing.T) {
 	// Arrange
 	file := File{

--- a/internal/utils/exporters/exporters.go
+++ b/internal/utils/exporters/exporters.go
@@ -31,6 +31,24 @@ func DisplayResults(sc types.CliFlags, results types.Results, formatResultsFunc 
 	return nil
 }
 
+// DisplayResultsFromMods formats and displays a slice of mod results. It takes command-line
+// flags, the mods to display, and a formatting function that accepts []ModInfo. Returns an
+// error if formatting fails.
+func DisplayResultsFromMods(sc types.CliFlags, mods []types.ModInfo, formatResultsFunc func([]types.ModInfo) (string, error)) error {
+	jsonResults, err := formatResultsFunc(mods)
+	if err != nil {
+		return fmt.Errorf("error while attempting to format results: %v", err)
+	}
+
+	if sc.Quiet {
+		fmt.Println(jsonResults)
+		return nil
+	}
+
+	formatters.PrintPrettyJson(jsonResults)
+	return nil
+}
+
 // SaveCookiesToJson saves the provided cookie data as a JSON file in the specified directory.
 // It checks if the directory exists, creates it if necessary, and uses provided functions to
 // open the file and ensure the directory exists. Returns an error if any operation fails.

--- a/internal/utils/exporters/exporters.go
+++ b/internal/utils/exporters/exporters.go
@@ -27,8 +27,7 @@ func DisplayResults(sc types.CliFlags, results types.Results, formatResultsFunc 
 		return nil
 	}
 
-	formatters.PrintPrettyJson(jsonResults)
-	return nil
+	return formatters.PrintPrettyJson(jsonResults)
 }
 
 // DisplayResultsFromMods formats and displays a slice of mod results. It takes command-line
@@ -45,8 +44,7 @@ func DisplayResultsFromMods(sc types.CliFlags, mods []types.ModInfo, formatResul
 		return nil
 	}
 
-	formatters.PrintPrettyJson(jsonResults)
-	return nil
+	return formatters.PrintPrettyJson(jsonResults)
 }
 
 // SaveCookiesToJson saves the provided cookie data as a JSON file in the specified directory.

--- a/internal/utils/exporters/exporters_test.go
+++ b/internal/utils/exporters/exporters_test.go
@@ -18,25 +18,30 @@ type Mocker struct {
 	mock.Mock
 }
 
+// FormatResultsAsJson returns the mock's canned result for DisplayResults tests.
 func (m *Mocker) FormatResultsAsJson(results types.ModInfo) (string, error) {
 	args := m.Called(results)
 	return args.String(0), args.Error(1)
 }
 
+// FormatResultsAsJsonFromMods returns the mock's canned result for multi-mod display tests.
 func (m *Mocker) FormatResultsAsJsonFromMods(mods []types.ModInfo) (string, error) {
 	args := m.Called(mods)
 	return args.String(0), args.Error(1)
 }
 
+// PrintPrettyJson is a no-op for the mock.
 func (m *Mocker) PrintPrettyJson(jsonData string) {
 	m.Called(jsonData)
 }
 
+// EnsureDirExists returns the mock's canned error for save tests.
 func (m *Mocker) EnsureDirExists(dir string) error {
 	args := m.Called(dir)
 	return args.Error(0)
 }
 
+// TestDisplayResults_Success verifies DisplayResults with valid format output.
 func TestDisplayResults_Success(t *testing.T) {
 	// Arrange
 	mockFormatter := new(Mocker)
@@ -98,6 +103,7 @@ func TestDisplayResults_Success(t *testing.T) {
 	mockFormatter.AssertCalled(t, "FormatResultsAsJson", results.Mods)
 }
 
+// TestDisplayResults_FormatError checks DisplayResults when formatting fails.
 func TestDisplayResults_FormatError(t *testing.T) {
 	// Arrange: Create a mock formatter and set expectations for the error
 	mockFormatter := new(Mocker)
@@ -125,6 +131,7 @@ func TestDisplayResults_FormatError(t *testing.T) {
 	mockFormatter.AssertCalled(t, "FormatResultsAsJson", results.Mods)
 }
 
+// TestSaveCookiesToJson_Success verifies successful cookie JSON save.
 func TestSaveCookiesToJson_Success(t *testing.T) {
 	// Arrange
 	dir := "testDir"
@@ -163,6 +170,7 @@ func TestSaveCookiesToJson_Success(t *testing.T) {
 	assert.Equal(t, expectedContent, string(fileContent))
 }
 
+// TestSaveModInfoToJson_Success verifies successful mod info JSON save.
 func TestSaveModInfoToJson_Success(t *testing.T) {
 	// Arrange
 	tempDir, err := os.MkdirTemp("", "testDir")
@@ -201,6 +209,7 @@ func TestSaveModInfoToJson_Success(t *testing.T) {
 	assert.Equal(t, expectedContent, string(fileContent))
 }
 
+// TestSaveModInfoToJson_EnsureDirExistsError checks error when EnsureDirExists fails.
 func TestSaveModInfoToJson_EnsureDirExistsError(t *testing.T) {
 	// Arrange
 	dir := "testDir"
@@ -225,6 +234,7 @@ func TestSaveModInfoToJson_EnsureDirExistsError(t *testing.T) {
 	mockUtils.AssertCalled(t, "EnsureDirExists", dir)
 }
 
+// TestDisplayResults_QuietMode verifies DisplayResults in quiet mode (plain JSON).
 func TestDisplayResults_QuietMode(t *testing.T) {
 	// Arrange
 	sc := types.CliFlags{
@@ -248,6 +258,7 @@ func TestDisplayResults_QuietMode(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestSaveCookiesToJson_EnsureDirExistsError checks error when directory creation fails for cookies.
 func TestSaveCookiesToJson_EnsureDirExistsError(t *testing.T) {
 	// Arrange
 	dir := "testDir"
@@ -270,6 +281,7 @@ func TestSaveCookiesToJson_EnsureDirExistsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "directory error")
 }
 
+// TestSaveCookiesToJson_OpenFileError checks error when opening the cookie file fails.
 func TestSaveCookiesToJson_OpenFileError(t *testing.T) {
 	// Arrange
 	dir := "testDir"
@@ -293,6 +305,7 @@ func TestSaveCookiesToJson_OpenFileError(t *testing.T) {
 	assert.Contains(t, err.Error(), "open file error")
 }
 
+// TestDisplayResultsFromMods_SingleMod verifies DisplayResultsFromMods with one mod.
 func TestDisplayResultsFromMods_SingleMod(t *testing.T) {
 	mods := []types.ModInfo{
 		{Name: "Mod1", ModID: 1, Creator: "Creator1"},
@@ -307,6 +320,7 @@ func TestDisplayResultsFromMods_SingleMod(t *testing.T) {
 	mockFormatter.AssertCalled(t, "FormatResultsAsJsonFromMods", mods)
 }
 
+// TestDisplayResultsFromMods_MultipleMods verifies DisplayResultsFromMods with multiple mods.
 func TestDisplayResultsFromMods_MultipleMods(t *testing.T) {
 	mods := []types.ModInfo{
 		{Name: "A", ModID: 1},
@@ -322,6 +336,7 @@ func TestDisplayResultsFromMods_MultipleMods(t *testing.T) {
 	mockFormatter.AssertCalled(t, "FormatResultsAsJsonFromMods", mods)
 }
 
+// TestDisplayResultsFromMods_QuietMode verifies DisplayResultsFromMods in quiet mode.
 func TestDisplayResultsFromMods_QuietMode(t *testing.T) {
 	sc := types.CliFlags{Quiet: true}
 	mods := []types.ModInfo{{Name: "Mod1", ModID: 1, Creator: "Creator1"}}
@@ -332,6 +347,7 @@ func TestDisplayResultsFromMods_QuietMode(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestDisplayResultsFromMods_FormatError checks DisplayResultsFromMods when formatting fails.
 func TestDisplayResultsFromMods_FormatError(t *testing.T) {
 	mods := []types.ModInfo{{Name: "Mod1", ModID: 1}}
 	mockFormatter := new(Mocker)
@@ -342,6 +358,7 @@ func TestDisplayResultsFromMods_FormatError(t *testing.T) {
 	assert.EqualError(t, err, "error while attempting to format results: format error")
 }
 
+// TestSaveModInfoToJson_WriteFileError checks error when writing the mod JSON file fails.
 func TestSaveModInfoToJson_WriteFileError(t *testing.T) {
 	// Arrange - use a directory that doesn't exist
 	dir := "/nonexistent/readonly/path"
@@ -364,6 +381,7 @@ func TestSaveModInfoToJson_WriteFileError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error saving file")
 }
 
+// TestSaveModInfoToJson_MarshalError checks error when JSON marshalling fails.
 func TestSaveModInfoToJson_MarshalError(t *testing.T) {
 	tempDir := t.TempDir()
 	mockUtils := new(Mocker)
@@ -378,6 +396,7 @@ func TestSaveModInfoToJson_MarshalError(t *testing.T) {
 	mockUtils.AssertCalled(t, "EnsureDirExists", tempDir)
 }
 
+// TestSaveCookiesToJson_MarshalError checks error when cookie JSON marshalling fails.
 func TestSaveCookiesToJson_MarshalError(t *testing.T) {
 	dir := t.TempDir()
 	mockUtils := new(Mocker)
@@ -400,18 +419,26 @@ func TestSaveCookiesToJson_MarshalError(t *testing.T) {
 	mockUtils.AssertCalled(t, "EnsureDirExists", dir)
 }
 
+// TestSaveCookiesToJson_WriteError checks error when writing the cookie file fails.
 func TestSaveCookiesToJson_WriteError(t *testing.T) {
 	dir := t.TempDir()
 	mockUtils := new(Mocker)
 	mockUtils.On("EnsureDirExists", dir).Return(nil)
 
-	// Use a directory path so "file" is not writable (open succeeds but Write fails when writing to dir)
+	// openFileFunc returns an already-closed temp file so SaveCookiesToJson's write fails.
+	// Expected error is "file already closed" (Go's error text). Using a temp regular file
+	// instead of a directory avoids Windows-specific behavior; adjust this fake opener if
+	// SaveCookiesToJson's file handling changes.
+	closedFile, err := os.CreateTemp(dir, "save-cookies-write-error")
+	assert.NoError(t, err)
+	closedFile.Close()
 	openFileFunc := func(name string, flag int, perm os.FileMode) (*os.File, error) {
-		return os.Open(dir) // open dir read-only; Write will fail
+		return closedFile, nil
 	}
 
 	data := map[string]string{"session": "1234"}
-	err := SaveCookiesToJson(dir, "cookies.json", data, openFileFunc, mockUtils.EnsureDirExists)
+	err = SaveCookiesToJson(dir, "cookies.json", data, openFileFunc, mockUtils.EnsureDirExists)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file already closed", "SaveCookiesToJson should report the write failure")
 	mockUtils.AssertCalled(t, "EnsureDirExists", dir)
 }

--- a/internal/utils/formatters/formatters.go
+++ b/internal/utils/formatters/formatters.go
@@ -87,6 +87,23 @@ func FormatResultsAsJson(mods types.ModInfo) (string, error) {
 	return string(jsonData), nil
 }
 
+// FormatResultsAsJsonFromMods formats a slice of ModInfo for display. For a single
+// mod it returns a single JSON object (backward compatible). For multiple mods it
+// returns a JSON array of objects.
+func FormatResultsAsJsonFromMods(mods []types.ModInfo) (string, error) {
+	if len(mods) == 0 {
+		return "[]", nil
+	}
+	if len(mods) == 1 {
+		return FormatResultsAsJson(mods[0])
+	}
+	jsonData, err := marshalIndent(mods, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal mod information: %w", err)
+	}
+	return string(jsonData), nil
+}
+
 // PrintJson prints a given JSON-formatted string to the standard output.
 func PrintJson(data string) {
 	fmt.Println(data)
@@ -135,5 +152,28 @@ func StrToInt(input string) (int64, error) {
 		return 0, err
 	}
 
+	return result, nil
+}
+
+// StrToInt64Slice parses a comma-separated string of integers into a slice of int64.
+// Spaces around commas are allowed. Empty segments (e.g. "1,,2") or invalid tokens
+// cause an error. Returns an error if the resulting slice would be empty.
+func StrToInt64Slice(input string) ([]int64, error) {
+	parts := strings.Split(input, ",")
+	var result []int64
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s == "" {
+			return nil, fmt.Errorf("empty mod id in list %q", input)
+		}
+		n, err := StrToInt(s)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, n)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no valid mod ids in %q", input)
+	}
 	return result, nil
 }

--- a/internal/utils/formatters/formatters.go
+++ b/internal/utils/formatters/formatters.go
@@ -175,9 +175,5 @@ func StrToInt64Slice(input string) ([]int64, error) {
 		}
 		result = append(result, n)
 	}
-	// Defensive: strings.Split(_, ",") plus the loop above only append on valid tokens, so result cannot be empty here unless we already returned an error.
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no valid mod ids in %q", input)
-	}
 	return result, nil
 }

--- a/internal/utils/formatters/formatters.go
+++ b/internal/utils/formatters/formatters.go
@@ -77,6 +77,9 @@ func CookieDomain(url string) string {
 // marshalIndent is used by FormatResultsAsJson; tests may override to simulate marshal failure.
 var marshalIndent = json.MarshalIndent
 
+// formatterMarshal is used by PrintPrettyJson; tests may override to simulate formatter marshal failure.
+var formatterMarshal = func(f *colorjson.Formatter, obj interface{}) ([]byte, error) { return f.Marshal(obj) }
+
 // FormatResultsAsJson takes a ModInfo object, formats it as a pretty-printed JSON
 // string, and returns the result. If marshalling fails, it returns an error.
 func FormatResultsAsJson(mods types.ModInfo) (string, error) {
@@ -128,7 +131,7 @@ func PrintPrettyJson(data string, useAltColors ...bool) error {
 		f.StringColor = color.New(color.FgHiMagenta)
 	}
 
-	s, err := f.Marshal(obj)
+	s, err := formatterMarshal(f, obj)
 	if err != nil {
 		return fmt.Errorf("failed to marshal formatted JSON: %w", err)
 	}
@@ -172,6 +175,7 @@ func StrToInt64Slice(input string) ([]int64, error) {
 		}
 		result = append(result, n)
 	}
+	// Defensive: strings.Split(_, ",") plus the loop above only append on valid tokens, so result cannot be empty here unless we already returned an error.
 	if len(result) == 0 {
 		return nil, fmt.Errorf("no valid mod ids in %q", input)
 	}

--- a/internal/utils/formatters/formatters_test.go
+++ b/internal/utils/formatters/formatters_test.go
@@ -151,6 +151,7 @@ func TestFormatResultsAsJson_MarshalError(t *testing.T) {
 	}
 }
 
+// TestFormatResultsAsJsonFromMods verifies FormatResultsAsJsonFromMods for single and multiple mods.
 func TestFormatResultsAsJsonFromMods(t *testing.T) {
 	single := types.ModInfo{Name: "Single", ModID: 1, LastChecked: time.Time{}}
 	multi := []types.ModInfo{
@@ -334,6 +335,7 @@ func TestStrToInt(t *testing.T) {
 	}
 }
 
+// TestStrToInt64Slice verifies parsing of comma-separated integer strings.
 func TestStrToInt64Slice(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/utils/spinners/spinners_test.go
+++ b/internal/utils/spinners/spinners_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 
+// TestCreateSpinner_StartAndStop verifies spinner start and stop behavior.
 func TestCreateSpinner_StartAndStop(t *testing.T) {
 	// Arrange
 	startMessage := "Starting..."
@@ -41,6 +42,7 @@ func TestCreateSpinner_StartAndStop(t *testing.T) {
 	}
 }
 
+// TestStopOnSignal_Interrupt verifies spinner stops on interrupt signal.
 func TestStopOnSignal_Interrupt(t *testing.T) {
 	// Arrange
 	spinner := CreateSpinner("Starting...", "✔", "Completed", "✘", "Failed")
@@ -72,6 +74,7 @@ func TestStopOnSignal_Interrupt(t *testing.T) {
 	}
 }
 
+// TestCreateSpinner_StopFail verifies StopFail behavior.
 func TestCreateSpinner_StopFail(t *testing.T) {
 	// Arrange
 	spinner := CreateSpinner("Processing...", "✔", "Done", "✘", "Error occurred")
@@ -92,6 +95,7 @@ func TestCreateSpinner_StopFail(t *testing.T) {
 	}
 }
 
+// TestCreateSpinner_StopMessage verifies StopMessage and Stop success path.
 func TestCreateSpinner_StopMessage(t *testing.T) {
 	// Arrange
 	spinner := CreateSpinner("Processing...", "✔", "Done", "✘", "Error occurred")

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -57,12 +58,8 @@ func TestConcurrentFetch_MultipleTasksFail(t *testing.T) {
 
 // TestEnsureDirExists_DirAlreadyExists verifies no error when directory exists.
 func TestEnsureDirExists_DirAlreadyExists(t *testing.T) {
-	// Arrange
-	existingDir := "existingDir"
-	if err := os.Mkdir(existingDir, os.ModePerm); err != nil {
-		t.Fatalf("setup: create test dir: %v", err)
-	}
-	defer os.Remove(existingDir) // Clean up after test
+	// Arrange: t.TempDir() already exists and is cleaned up by the test framework
+	existingDir := t.TempDir()
 
 	// Act
 	err := EnsureDirExists(existingDir)
@@ -75,9 +72,8 @@ func TestEnsureDirExists_DirAlreadyExists(t *testing.T) {
 
 // TestEnsureDirExists_DirDoesNotExist verifies directory is created when missing.
 func TestEnsureDirExists_DirDoesNotExist(t *testing.T) {
-	// Arrange
-	newDir := "newDir"
-	defer os.Remove(newDir) // Clean up after test
+	// Arrange: path under temp dir that does not exist yet; temp dir is cleaned up automatically
+	newDir := filepath.Join(t.TempDir(), "newDir")
 
 	// Act
 	err := EnsureDirExists(newDir)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 )
 
+// TestConcurrentFetch_FirstTaskFails verifies the first task's error is returned.
 func TestConcurrentFetch_FirstTaskFails(t *testing.T) {
 	// Arrange
 	expectedErr := errors.New("task1 failed")
@@ -21,6 +22,7 @@ func TestConcurrentFetch_FirstTaskFails(t *testing.T) {
 	}
 }
 
+// TestConcurrentFetch_SecondTaskFails verifies the second task's error is returned.
 func TestConcurrentFetch_SecondTaskFails(t *testing.T) {
 	// Arrange
 	expectedErr := errors.New("task2 failed")
@@ -36,6 +38,7 @@ func TestConcurrentFetch_SecondTaskFails(t *testing.T) {
 	}
 }
 
+// TestConcurrentFetch_MultipleTasksFail verifies one of the errors is returned.
 func TestConcurrentFetch_MultipleTasksFail(t *testing.T) {
 	// Arrange
 	task1Err := errors.New("task1 failed")
@@ -52,6 +55,7 @@ func TestConcurrentFetch_MultipleTasksFail(t *testing.T) {
 	}
 }
 
+// TestEnsureDirExists_DirAlreadyExists verifies no error when directory exists.
 func TestEnsureDirExists_DirAlreadyExists(t *testing.T) {
 	// Arrange
 	existingDir := "existingDir"
@@ -67,6 +71,7 @@ func TestEnsureDirExists_DirAlreadyExists(t *testing.T) {
 	}
 }
 
+// TestEnsureDirExists_DirDoesNotExist verifies directory is created when missing.
 func TestEnsureDirExists_DirDoesNotExist(t *testing.T) {
 	// Arrange
 	newDir := "newDir"
@@ -87,6 +92,7 @@ func TestEnsureDirExists_DirDoesNotExist(t *testing.T) {
 	}
 }
 
+// TestEnsureDirExists_CannotCreateDir verifies error when directory cannot be created.
 func TestEnsureDirExists_CannotCreateDir(t *testing.T) {
 	// Arrange
 	invalidDir := "" // Empty directory name should cause an error

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -59,8 +59,10 @@ func TestConcurrentFetch_MultipleTasksFail(t *testing.T) {
 func TestEnsureDirExists_DirAlreadyExists(t *testing.T) {
 	// Arrange
 	existingDir := "existingDir"
-	os.Mkdir(existingDir, os.ModePerm) // Create the directory for the test
-	defer os.Remove(existingDir)       // Clean up after test
+	if err := os.Mkdir(existingDir, os.ModePerm); err != nil {
+		t.Fatalf("setup: create test dir: %v", err)
+	}
+	defer os.Remove(existingDir) // Clean up after test
 
 	// Act
 	err := EnsureDirExists(existingDir)

--- a/nexus-mods-scraper_test.go
+++ b/nexus-mods-scraper_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestExecuteMain_Success verifies executeMain exits without error when Execute succeeds.
 func TestExecuteMain_Success(t *testing.T) {
 	mockExecute := func() error {
 		return nil
@@ -31,6 +32,7 @@ func TestExecuteMain_Success(t *testing.T) {
 	assert.Empty(t, stderrBuf.String(), "stderr should remain empty on success")
 }
 
+// TestExecuteMain_FailureOnExecute verifies executeMain exits with code 1 and prints error to stderr.
 func TestExecuteMain_FailureOnExecute(t *testing.T) {
 	executeErr := errors.New("execute failed")
 	mockExecute := func() error {
@@ -61,6 +63,7 @@ func TestExecuteMain_FailureOnExecute(t *testing.T) {
 	assert.Contains(t, stderrBuf.String(), executeErr.Error(), "stderr should contain the error message")
 }
 
+// TestMain_CoversEntryPoint exercises main() entry point with mocked osExit.
 func TestMain_CoversEntryPoint(t *testing.T) {
 	oldOsExit := osExit
 	oldArgs := os.Args


### PR DESCRIPTION
- feat(core): added ability to scrape multiple mod id's
- Fixes: #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI accepts a single mod ID or comma-separated list; scrapes multiple mods in one run, saving one JSON file per mod. Added global --quiet flag to skip terminal clearing.

* **Documentation**
  * Updated usage, examples, and Output wording to show multi-mod syntax, whitespace-tolerant IDs, single vs. multiple outputs, and per-mod save behavior.

* **Tests**
  * Vastly expanded test coverage for multi-ID parsing, multi-mod display/save flows, error paths, cookie extraction, spinners, and related utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->